### PR TITLE
Til 86 에러 처리 개선

### DIFF
--- a/src/src/ExceptionFilters/Errors/Validation/Validation.error.ts
+++ b/src/src/ExceptionFilters/Errors/Validation/Validation.error.ts
@@ -1,0 +1,18 @@
+import Error from 'src/ExceptionFilters/Interface/Error.interface';
+
+// 요청 데이터검증에 실패했을 경우
+export class ValidationFailed implements Error {
+  // 개발자 코멘트를 생성자 매개변수로 할당할 수 있다.
+  constructor(public readonly description?) {}
+
+  // 미리 정의된 에러코드
+  public readonly codeNumber = 400;
+
+  public readonly codeText = 'ValidationFailed';
+
+  // 미리 정의된 메시지 객체
+  public readonly message = {
+    en: 'Validation failed',
+    kr: '요청한 데이터가 올바르지 않습니다.',
+  };
+}

--- a/src/src/ExceptionFilters/HttpException.filter.ts
+++ b/src/src/ExceptionFilters/HttpException.filter.ts
@@ -6,29 +6,40 @@ import Error from './Interface/Error.interface';
 export class HttpExceptionFilter implements ExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
-    const response = ctx.getResponse<Response>();
-    const request = ctx.getRequest<Request>();
-    const status = exception.getStatus();
-    const errorData = exception.getResponse() as Error;
 
-    // Error Logging
+    // 요청
+    const request = ctx.getRequest<Request>();
+
+    // 응답
+    const response = ctx.getResponse<Response>();
+
+    // 사용자 정의된 에러 객체
+    const errorData = exception.getResponse() as Error | any;
+
+    // Error Mapping
+    const status = exception.getStatus();
+    const requestLocation = request.url;
+    const errorObjectCode = !errorData.codeText ? errorData.error : errorData.codeText;
+    const devDescription = !errorData.description ? 'not found error description' : errorData.description;
+    const message = errorData.message;
+
+    // Logging
     Logger.error(`
-      code : ${errorData.codeNumber}
-      location : ${request.url}
-      errorCode : ${errorData.codeText}
-      description : ${errorData.description || '개발자 코멘트가 존재하지 않습니다.'}
-      message : ${errorData.message.en}
-      message : ${errorData.message.kr || '한국어 에러 메시지가 정의되지 않았습니다.'}
+      statusCode : ${status}
+      location : ${requestLocation}
+      errorObjectCode : ${errorObjectCode}
+      description : ${devDescription}
+      message : ${JSON.stringify(message)}
       `);
 
     // Error response
     response.status(status).json({
-      error: 'true',
+      error: true,
       statusCode: status,
       timestamp: new Date().toISOString(),
-      location: request.url,
-      errorCode: errorData.codeText,
-      message: errorData.message,
+      location: requestLocation,
+      errorCode: errorObjectCode,
+      message: message,
     });
   }
 }


### PR DESCRIPTION
# 변경사항
---
![image](https://user-images.githubusercontent.com/55491354/146039889-7325fc58-357d-45d6-9eba-cdc2ee354c3e.png)
에러 데이터를 응답 객체에 적재하기전에 맵핑과정을 거칩니다

![image](https://user-images.githubusercontent.com/55491354/146040336-4ea1b15d-afe0-4aca-886a-9b646df6f2a0.png)
익셉션 팩토리를 통해 에러가 발생했을 경우 사용자에게 추가정보를 제공하지 않습니다.

# 문제점
---
![image](https://user-images.githubusercontent.com/55491354/146040016-cb486eb2-74a4-4aab-a089-d8255b74c09c.png)
글로벌 익셉션 필터에서 벨리데이션 에러, 파이프 에러, 사전 정의된 에러 객체 3가지를 동시에 받아오기 때문에
타입 다운캐스팅이 필요합니다.